### PR TITLE
RomWBW support update

### DIFF
--- a/bankswitch.s
+++ b/bankswitch.s
@@ -10,9 +10,9 @@
     .globl _bank_switch_method
     .globl _una_entry_vector
 
-; RomWBW entry vectors
-ROMWBW_SETBNK      .equ 0xFC06
-ROMWBW_GETBNK      .equ 0xFC09
+; RomWBW fixed address vectors/storage
+ROMWBW_SETBNK      .equ 0xFFF3 ; RomWBW SETBNK function vector
+ROMWBW_CURBNK      .equ 0xFFE0 ; RomWBW current bank id byte adr
 
 ; UNA BIOS banked memory functions
 UNABIOS_ENTRY      .equ 0x08 ; entry vector
@@ -93,8 +93,8 @@ _bankswitch_get_current_bank:
     ld hl, #0
     ret
 getbank_romwbw:
-    call #ROMWBW_GETBNK
-    ; returns page number in A
+    ; load current page number to A
+    ld a, (#ROMWBW_CURBNK)
     ld h, #0
     ld l, a
     ret

--- a/flash4.c
+++ b/flash4.c
@@ -412,7 +412,8 @@ bool una_bios_present(void)
 
 bool romwbw_bios_present(void)
 {
-    return (*((unsigned int*)CPM_SIGNATURE_ADDR) == CPM_SIGNATURE_ROMWBW);
+    unsigned int **bios_signature = (unsigned int **)BIOS_SIGNATURE_ADDR;
+    return (**bios_signature == BIOS_SIGNATURE_ROMWBW);
 }
 
 static const char *bpbios_p112_signature = "B/P-DX";
@@ -449,7 +450,7 @@ void main(int argc, char *argv[])
     cpm_fcb imagefile;
     bool allow_partial=false;
     bool rom_mode=false;
-    printf("FLASH4 by Will Sowerbutts <will@sowerbutts.com> version 1.2.0\n\n");
+    printf("FLASH4 by Will Sowerbutts <will@sowerbutts.com> version 1.2.1\n\n");
 
     /* determine access mode */
     for(i=1; i<argc; i++){ /* check for manual mode override */
@@ -549,7 +550,7 @@ void main(int argc, char *argv[])
                "\tFLASH4 WRITE filename [options]\n\n" \
                "Options (access method is auto-detected by default)\n" \
                "\t/PARTIAL\tAllow flashing a large ROM from a smaller image file\n" \
-               "\t/ROM\tAllow read-only use of unknown chip types\n" \
+               "\t/ROM\t\tAllow read-only use of unknown chip types\n" \
                "\t/Z180DMA\tForce Z180 DMA engine\n" \
                "\t/ROMWBW \tForce RomWBW bank switching\n" \
                "\t/UNABIOS\tForce UNA BIOS bank switching\n" \

--- a/libcpm.h
+++ b/libcpm.h
@@ -13,7 +13,7 @@
 
 #define BIOS_SIGNATURE_ADDR           0xFFFE
 #define BIOS_SIGNATURE_UNA            0xE5FD
-// no BIOS_SIGNATURE_ROMWBW yet defined
+#define BIOS_SIGNATURE_ROMWBW         0xA857
 
 /* File control block -- see http://www.seasip.demon.co.uk/Cpm/fcb.html */
 typedef struct cpm_fcb {


### PR DESCRIPTION
Revise RomWBW detection and bank management due to recent changes in
RomWBW.  Will be compatible with RomWBW 2.6+.  RomWBW versions prior to
2.6 will not be detected nor functional.
